### PR TITLE
docs: update copyright notice

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 WebGazer.js - Scalable browser-based webcam eye tracking
 
-Copyright (C) 2016 Brown WebGazer Team
+Copyright (c) 2026 New York University (Denis Pelli and the EasyEyes team)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Summary

- update the license copyright notice to 2026
- standardize ownership as New York University (Denis Pelli and the EasyEyes team)

## Verification

- verified the commit changes only the repository license file